### PR TITLE
Remove dependencies to external request packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
 
 install:
   - composer install --dev --no-interaction
+  - composer require --dev symfony/http-foundation
+  - composer require --dev guzzlehttp/guzzle:5.*
 
 script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^7.5",
+        "nyholm/psr7": "^1.1"
     },
     "suggest": {
         "symfony/http-foundation": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "symfony/http-foundation": "^4.1",
-        "psr/http-message": "^1.0",
-        "guzzlehttp/guzzle": "^5.0"
+        "psr/http-message": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -26,5 +24,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"
+    },
+    "suggest": {
+        "symfony/http-foundation": "^4.1",
+        "guzzlehttp/guzzle": "^5.0"
     }
 }

--- a/src/Hmac/Adapter/RequestAdapterFactory.php
+++ b/src/Hmac/Adapter/RequestAdapterFactory.php
@@ -2,9 +2,7 @@
 
 namespace Starlit\Request\Authenticator\Hmac\Adapter;
 
-use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Psr\Http\Message\RequestInterface as Psr7Request;
-use GuzzleHttp\Message\Request as Guzzle5Request;
 
 class RequestAdapterFactory implements RequestAdapterFactoryInterface
 {
@@ -12,10 +10,13 @@ class RequestAdapterFactory implements RequestAdapterFactoryInterface
     {
         if ($request instanceof Psr7Request) {
             return new Psr7RequestAdapter($request);
-        } elseif ($request instanceof SymfonyRequest) {
+        } elseif (class_exists('\Symfony\Component\HttpFoundation\Request')
+            && $request instanceof \Symfony\Component\HttpFoundation\Request)
+        {
             return new SymfonyRequestAdapter($request);
-        } elseif ($request instanceof Guzzle5Request) {
-            return new Guzzle5RequestAdapter($request);
+        } elseif (class_exists('\GuzzleHttp\Message\Request')
+            && $request instanceof \GuzzleHttp\Message\Request) {
+                return new Guzzle5RequestAdapter($request);
         } else {
             throw new \InvalidArgumentException(
                 'Request type not supported. Only PSR-7, Symfony or Guzzle5 requests are supported.'

--- a/tests/Hmac/Adapter/Guzzle5RequestAdapterTest.php
+++ b/tests/Hmac/Adapter/Guzzle5RequestAdapterTest.php
@@ -2,7 +2,6 @@
 
 namespace Starlit\Request\Authenticator\Tests\Hmac\Adapter;
 
-use GuzzleHttp\Message\Request;
 use PHPUnit\Framework\TestCase;
 use Starlit\Request\Authenticator\Hmac\Adapter\Guzzle5RequestAdapter;
 use Starlit\Request\Authenticator\Hmac\Adapter\RequestAdapterInterface;
@@ -18,14 +17,18 @@ class Guzzle5RequestAdapterTest extends TestCase
      */
     public function testAdaption()
     {
-        $uri = 'http://foo.test/bar?paramB=b&paramA=a';
-        $guzzle5Request = new Request('GET', $uri);
-        $request = new Guzzle5RequestAdapter($guzzle5Request);
+        if (class_exists('GuzzleHttp\Message\Request')) {
+            $uri = 'http://foo.test/bar?paramB=b&paramA=a';
+            $guzzle5Request = new \GuzzleHttp\Message\Request('GET', $uri);
+            $request = new Guzzle5RequestAdapter($guzzle5Request);
 
-        $this->assertInstanceOf(RequestAdapterInterface::class, $request);
-        $this->assertSame('GET', $request->getMethod());
-        $this->assertSame($uri, $request->getUri());
-        $this->assertSame('', $request->getContent());
-        $this->assertNull($request->getHeader('MAC'));
+            $this->assertInstanceOf(RequestAdapterInterface::class, $request);
+            $this->assertSame('GET', $request->getMethod());
+            $this->assertSame($uri, $request->getUri());
+            $this->assertSame('', $request->getContent());
+            $this->assertNull($request->getHeader('MAC'));
+        } else {
+            $this->assertTrue(true, 'guzzlehttp/guzzle version 5 package not loaded');
+        }
     }
 }

--- a/tests/Hmac/Adapter/RequestAdapterFactoryTest.php
+++ b/tests/Hmac/Adapter/RequestAdapterFactoryTest.php
@@ -4,8 +4,6 @@ namespace Starlit\Request\Authenticator\Tests\Hmac\Adapter;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\StreamInterface;
-use Psr\Http\Message\UriInterface;
 use Starlit\Request\Authenticator\Hmac\Adapter\Guzzle5RequestAdapter;
 use Starlit\Request\Authenticator\Hmac\Adapter\Psr7RequestAdapter;
 use Starlit\Request\Authenticator\Hmac\Adapter\RequestAdapterFactory;
@@ -43,11 +41,16 @@ class RequestAdapterFactoryTest extends TestCase
      */
     public function testCreateSymfonyRequest()
     {
-        $symfonyRequest = new SymfonyRequest();
-        $request = $this->factory->create($symfonyRequest);
+        if (class_exists('Symfony\Component\HttpFoundation\Request')) {
 
-        $this->assertInstanceOf(RequestAdapterInterface::class, $request);
-        $this->assertInstanceOf(SymfonyRequestAdapter::class, $request);
+            $symfonyRequest = new SymfonyRequest();
+            $request = $this->factory->create($symfonyRequest);
+
+            $this->assertInstanceOf(RequestAdapterInterface::class, $request);
+            $this->assertInstanceOf(SymfonyRequestAdapter::class, $request);
+        } else {
+            $this->assertTrue(true, 'symfony/http-foundation package not loaded');
+        }
     }
 
     /**
@@ -55,11 +58,15 @@ class RequestAdapterFactoryTest extends TestCase
      */
     public function testCreateGuzzle5Request()
     {
-        $psr7Request = new Guzzle5Request('GET', '/foo');
-        $request = $this->factory->create($psr7Request);
+        if (class_exists('Symfony\Component\HttpFoundation\Request')) {
+            $psr7Request = new Guzzle5Request('GET', '/foo');
+            $request = $this->factory->create($psr7Request);
 
-        $this->assertInstanceOf(RequestAdapterInterface::class, $request);
-        $this->assertInstanceOf(Guzzle5RequestAdapter::class, $request);
+            $this->assertInstanceOf(RequestAdapterInterface::class, $request);
+            $this->assertInstanceOf(Guzzle5RequestAdapter::class, $request);
+        } else {
+            $this->assertTrue(true, 'guzzlehttp/guzzle version 5 package not loaded');
+        }
     }
 
     /**

--- a/tests/Hmac/Adapter/RequestAdapterFactoryTest.php
+++ b/tests/Hmac/Adapter/RequestAdapterFactoryTest.php
@@ -9,8 +9,6 @@ use Starlit\Request\Authenticator\Hmac\Adapter\Psr7RequestAdapter;
 use Starlit\Request\Authenticator\Hmac\Adapter\RequestAdapterFactory;
 use Starlit\Request\Authenticator\Hmac\Adapter\RequestAdapterInterface;
 use Starlit\Request\Authenticator\Hmac\Adapter\SymfonyRequestAdapter;
-use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
-use GuzzleHttp\Message\Request as Guzzle5Request;
 
 class RequestAdapterFactoryTest extends TestCase
 {
@@ -41,9 +39,9 @@ class RequestAdapterFactoryTest extends TestCase
      */
     public function testCreateSymfonyRequest()
     {
-        if (class_exists('Symfony\Component\HttpFoundation\Request')) {
+        if (class_exists('\Symfony\Component\HttpFoundation\Request')) {
 
-            $symfonyRequest = new SymfonyRequest();
+            $symfonyRequest = new \Symfony\Component\HttpFoundation\Request();
             $request = $this->factory->create($symfonyRequest);
 
             $this->assertInstanceOf(RequestAdapterInterface::class, $request);
@@ -58,8 +56,8 @@ class RequestAdapterFactoryTest extends TestCase
      */
     public function testCreateGuzzle5Request()
     {
-        if (class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $psr7Request = new Guzzle5Request('GET', '/foo');
+        if (class_exists('\GuzzleHttp\Message\Request')) {
+            $psr7Request = new \GuzzleHttp\Message\Request('GET', '/foo');
             $request = $this->factory->create($psr7Request);
 
             $this->assertInstanceOf(RequestAdapterInterface::class, $request);

--- a/tests/Hmac/Adapter/SymfonyRequestAdapterTest.php
+++ b/tests/Hmac/Adapter/SymfonyRequestAdapterTest.php
@@ -28,7 +28,7 @@ class SymfonyRequestAdapterTest extends TestCase
             $this->assertSame('', $request->getContent());
             $this->assertNull($request->getHeader('MAC'));
         } else {
-            $this->assertTrue(true, 'symfony/http-foundation library not loaded');
+            $this->assertTrue(true, 'symfony/http-foundation package not loaded');
         }
     }
 }

--- a/tests/Hmac/Adapter/SymfonyRequestAdapterTest.php
+++ b/tests/Hmac/Adapter/SymfonyRequestAdapterTest.php
@@ -5,7 +5,6 @@ namespace Starlit\Request\Authenticator\Tests\Hmac\Adapter;
 use PHPUnit\Framework\TestCase;
 use Starlit\Request\Authenticator\Hmac\Adapter\RequestAdapterInterface;
 use Starlit\Request\Authenticator\Hmac\Adapter\SymfonyRequestAdapter;
-use Symfony\Component\HttpFoundation\Request;
 
 class SymfonyRequestAdapterTest extends TestCase
 {
@@ -18,14 +17,18 @@ class SymfonyRequestAdapterTest extends TestCase
      */
     public function testAdaption()
     {
-        $uri = 'http://foo.test/bar?paramB=b&paramA=a';
-        $symfonyRequest = Request::create($uri);
-        $request = new SymfonyRequestAdapter($symfonyRequest);
+        if (class_exists('Symfony\Component\HttpFoundation\Request')) {
+            $uri = 'http://foo.test/bar?paramB=b&paramA=a';
+            $symfonyRequest = \Symfony\Component\HttpFoundation\Request::create($uri);
+            $request = new SymfonyRequestAdapter($symfonyRequest);
 
-        $this->assertInstanceOf(RequestAdapterInterface::class, $request);
-        $this->assertSame('GET', $request->getMethod());
-        $this->assertSame($uri, $request->getUri());
-        $this->assertSame('', $request->getContent());
-        $this->assertNull($request->getHeader('MAC'));
+            $this->assertInstanceOf(RequestAdapterInterface::class, $request);
+            $this->assertSame('GET', $request->getMethod());
+            $this->assertSame($uri, $request->getUri());
+            $this->assertSame('', $request->getContent());
+            $this->assertNull($request->getHeader('MAC'));
+        } else {
+            $this->assertTrue(true, 'symfony/http-foundation library not loaded');
+        }
     }
 }

--- a/tests/Hmac/HmacAuthenticatorTest.php
+++ b/tests/Hmac/HmacAuthenticatorTest.php
@@ -2,12 +2,12 @@
 
 namespace Starlit\Request\Authenticator\Tests\Hmac;
 
+use Nyholm\Psr7\Request;
 use PHPUnit\Framework\TestCase;
 use Starlit\Request\Authenticator\AuthenticatorInterface;
 use Starlit\Request\Authenticator\Hmac\Adapter\RequestAdapterFactory;
 use Starlit\Request\Authenticator\Hmac\HmacAuthenticator;
 use Starlit\Request\Authenticator\Hmac\HmacGenerator;
-use Symfony\Component\HttpFoundation\Request;
 
 class HmacAuthenticatorTest extends TestCase
 {
@@ -34,10 +34,10 @@ class HmacAuthenticatorTest extends TestCase
     /**
      * @covers \Starlit\Request\Authenticator\Hmac\HmacAuthenticator::authenticateRequest()
      */
-    public function testAuthenticateSymfonyRequest(): void
+    public function testAuthenticateRequest(): void
     {
-        $request = Request::create('/foo');
-        $request->headers->add(['MAC' => '1ade58546c1bf2cec5b80cf75e48719a28d5e542d4582b62790d4827366826cc']);
+        $request = new Request('GET', 'http://localhost/foo');
+        $request = $request->withHeader('MAC', '1ade58546c1bf2cec5b80cf75e48719a28d5e542d4582b62790d4827366826cc');
         $this->assertTrue($this->authenticator->authenticateRequest($request));
     }
 
@@ -46,7 +46,7 @@ class HmacAuthenticatorTest extends TestCase
      */
     public function testAuthenticateRequestWithMissingMacHeader(): void
     {
-        $request = Request::create('/foo');
+        $request = new Request('GET', 'http://localhost/foo');
         $this->assertFalse($this->authenticator->authenticateRequest($request));
     }
 }

--- a/tests/Hmac/HmacGeneratorTest.php
+++ b/tests/Hmac/HmacGeneratorTest.php
@@ -2,11 +2,12 @@
 
 namespace Starlit\Request\Authenticator\Tests\Hmac;
 
+use Nyholm\Psr7\Request;
 use PHPUnit\Framework\TestCase;
+use Starlit\Request\Authenticator\Hmac\Adapter\Psr7RequestAdapter;
 use Starlit\Request\Authenticator\Hmac\Adapter\SymfonyRequestAdapter;
 use Starlit\Request\Authenticator\Hmac\HmacGenerator;
 use Starlit\Request\Authenticator\Hmac\Transformer\RequestHmacDataTransformer;
-use Symfony\Component\HttpFoundation\Request;
 
 class HmacGeneratorTest extends TestCase
 {
@@ -92,8 +93,8 @@ class HmacGeneratorTest extends TestCase
      */
     public function testGenerateHmacForRequest(): void
     {
-        $request = Request::create('/foo');
-        $hmac = $this->generator->generateHmacForRequest(new SymfonyRequestAdapter($request));
+        $request = new Request('GET', 'http://localhost/foo');
+        $hmac = $this->generator->generateHmacForRequest(new Psr7RequestAdapter($request));
         $this->assertIsString($hmac);
         $this->assertSame('c38d090572c79b214a7165da2dec4be9cdd8acf607bbb950dba2ca5a24073358', $hmac);
     }
@@ -110,8 +111,8 @@ class HmacGeneratorTest extends TestCase
             ->willReturn("GET http://localhost/foo\n");
 
         $generator = new HmacGenerator('my secret', $hmacDataTransformerMock);
-        $request = Request::create('/foo');
-        $hmac = $generator->generateHmacForRequest(new SymfonyRequestAdapter($request));
+        $request = new Request('GET', 'http://localhost/foo');
+        $hmac = $generator->generateHmacForRequest(new Psr7RequestAdapter($request));
         $this->assertIsString($hmac);
         $this->assertSame('c38d090572c79b214a7165da2dec4be9cdd8acf607bbb950dba2ca5a24073358', $hmac);
     }

--- a/tests/Hmac/Transformer/RequestHmacDataTransformerTest.php
+++ b/tests/Hmac/Transformer/RequestHmacDataTransformerTest.php
@@ -7,10 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Starlit\Request\Authenticator\Hmac\Adapter\RequestAdapterFactory;
 use Starlit\Request\Authenticator\Hmac\Transformer\HmacDataTransformerInterface;
 use Starlit\Request\Authenticator\Hmac\Transformer\RequestHmacDataTransformer;
-use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
-use GuzzleHttp\Psr7\Request as Psr7Request;
-use GuzzleHttp\Message\Request as Guzzle5Request;
-
+use Nyholm\Psr7\Request as Psr7Request;
 
 class RequestHmacDataTransformerTest extends TestCase
 {
@@ -45,13 +42,26 @@ class RequestHmacDataTransformerTest extends TestCase
     {
         $uri = 'http://foobar.test/foo?param=value';
         $psr7Request = new Psr7Request('GET', $uri, [], 'bar');
-        $symfonyRequest = SymfonyRequest::create($uri, SymfonyRequest::METHOD_GET, [], [], [], [], 'bar');
-        $guzzle5Request = new Guzzle5Request('GET', $uri, [], Stream::factory('bar'));
+        $validRequests = [[$psr7Request]];
 
-        return [
-            [$psr7Request],
-            [$symfonyRequest],
-            [$guzzle5Request]
-        ];
+        if (class_exists('\Symfony\Component\HttpFoundation\Request')) {
+            $symfonyRequest = \Symfony\Component\HttpFoundation\Request::create(
+                $uri,
+                \Symfony\Component\HttpFoundation\Request::METHOD_GET,
+                [],
+                [],
+                [],
+                [],
+                'bar'
+            );
+            $validRequests[] = [$symfonyRequest];
+        }
+
+        if (class_exists('\GuzzleHttp\Message\Request')) {
+            $guzzle5Request = new \GuzzleHttp\Message\Request('GET', $uri, [], Stream::factory('bar'));
+            $validRequests[] = [$guzzle5Request];
+        }
+
+        return $validRequests;
     }
 }


### PR DESCRIPTION
Requiring external request packages makes it impossible to use the library with e.g. Guzzle6, thus the external packages needs to be supported optionally. This PR:

- removes the dependencies for `symfony/http-foundation` and `guzzlehttp/guzzle` and moves them to the suggested packages instead in the composer configuration
- refactors the `RequestAdapterFactory::create` method to check if the classes of the package exist
- refactors the tests to be processed only if the classes exist